### PR TITLE
Live draft display

### DIFF
--- a/app/assets/stylesheets/spina/admin/application.scss
+++ b/app/assets/stylesheets/spina/admin/application.scss
@@ -1,0 +1,25 @@
+@import 'spina';
+.article-status {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 52px;
+  width: 7px;
+  transition: all 0.2s;
+  &.live {
+    background-color: $primary-color;
+  }
+  &.draft {
+    background-color: #c3c3c3;
+  }
+  &.scheduled {
+    background-color: #65b2b4;
+  }
+}
+
+.dd-item:hover {
+  .article-status {
+    opacity: 0.7;
+    width: 9px;
+  }
+}

--- a/app/controllers/spina/admin/articles_controller.rb
+++ b/app/controllers/spina/admin/articles_controller.rb
@@ -7,7 +7,7 @@ module Spina
       layout "spina/admin/admin"
 
       def index
-        @articles = Spina::Article.order(:title).all
+        @articles = Article.order(publish_date: :desc)
       end
 
       def new
@@ -24,7 +24,7 @@ module Spina
           render :new
         end
       end
-      
+
       def edit
         add_breadcrumb @article.title
       end

--- a/app/models/spina/article.rb
+++ b/app/models/spina/article.rb
@@ -13,6 +13,18 @@ module Spina
     scope :live, -> { where('publish_date <= ? AND draft = ?', Date.today, 0) }
     scope :newest_first, -> { order('publish_date DESC') }
 
+    def live?
+      true if self.publish_date <= Date.today && draft == 0
+    end
+
+    def scheduled?
+      true if self.publish_date >= Date.today && draft == 0
+    end
+
+    def draft?
+      draft == 1
+    end
+
     def materialized_path
       "/news/#{slug}"
     end
@@ -24,6 +36,7 @@ module Spina
     def prev_article
       self.class.where("id < ?", id).order("id DESC").first
     end
+
 
     private
 

--- a/app/views/spina/admin/articles/_article.html.haml
+++ b/app/views/spina/admin/articles/_article.html.haml
@@ -2,6 +2,10 @@
   %div.dd-item-inner
     = link_to spina.edit_admin_article_path(article), class: 'button button-link button-small sortable-link' do
       = article.title
+      %span.article-status
+        = 'live' if article.live?
+        = 'scheduled' if article.scheduled?
+        = 'draft' if article.draft?
     %span.pull-right
       = link_to spina.edit_admin_article_path(article), class: 'button button-small button-link dd-nodrag' do
         = icon('pencil-outline')

--- a/app/views/spina/admin/articles/_article.html.haml
+++ b/app/views/spina/admin/articles/_article.html.haml
@@ -1,11 +1,13 @@
 %li.dd-item
   %div.dd-item-inner
+    - if article.live?
+      %div.article-status.live
+    - if article.draft?
+      %div.article-status.draft
+    - if article.scheduled?
+      %div.article-status.scheduled
     = link_to spina.edit_admin_article_path(article), class: 'button button-link button-small sortable-link' do
       = article.title
-      %span.article-status
-        = 'live' if article.live?
-        = 'scheduled' if article.scheduled?
-        = 'draft' if article.draft?
     %span.pull-right
       = link_to spina.edit_admin_article_path(article), class: 'button button-small button-link dd-nodrag' do
         = icon('pencil-outline')


### PR DESCRIPTION
Orders articles in Published date descending
Adds 3 news methods to model: live? draft? scheduled?
Condition in index view
Styles for statuses in index view

![image](https://user-images.githubusercontent.com/7274458/31552399-4668e87c-b02f-11e7-8672-c527432493fa.png)

Be nice to have a Key somewhere so users know what the colours are.