### PR TITLE
Added rails version to migrations for rails 5.1.x compat

### DIFF
--- a/lib/generators/spina_articles/templates/add_photo_id_to_spina_articles.rb
+++ b/lib/generators/spina_articles/templates/add_photo_id_to_spina_articles.rb
@@ -1,4 +1,4 @@
-class AddPhotoIdToSpinaArticles < ActiveRecord::Migration
+class AddPhotoIdToSpinaArticles < ActiveRecord::Migration[5.0]
   def change
     add_column :spina_articles, :photo_id, :integer
   end

--- a/lib/generators/spina_articles/templates/create_spina_articles_table.rb
+++ b/lib/generators/spina_articles/templates/create_spina_articles_table.rb
@@ -1,4 +1,4 @@
-class CreateSpinaArticlesTable < ActiveRecord::Migration
+class CreateSpinaArticlesTable < ActiveRecord::Migration[5.0]
   def change
     create_table :spina_articles do |t|
       t.string :title


### PR DESCRIPTION
This prevents the following exception when running `rails db:migrate`

```
StandardError: An error has occurred, all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateSpinaArticlesTable < ActiveRecord::Migration[4.2]
```